### PR TITLE
Update R-devel URL for macOS

### DIFF
--- a/setup-r/lib/installer.js
+++ b/setup-r/lib/installer.js
@@ -327,7 +327,7 @@ function getFileNameMacOS(version) {
 }
 function getDownloadUrlMacOS(version) {
     if (version == "devel") {
-        return "http://mac.r-project.org/el-capitan/R-devel/R-devel-el-capitan-signed.pkg";
+        return "http://mac.r-project.org/high-sierra/R-4.0-branch/R-4.0-branch.pkg";
     }
     const filename = getFileNameMacOS(version);
     if (semver.eq(version, "3.2.5")) {


### PR DESCRIPTION
Similar to https://github.com/travis-ci/travis-build/pull/1885

This just updates the R-devel URL to:

http://mac.r-project.org/high-sierra/R-4.0-branch/R-4.0-branch.pkg

I've opted not to change the gfortran install from homebrew, but I can add that as well.